### PR TITLE
Respect --builddir argument

### DIFF
--- a/cabal-src.cabal
+++ b/cabal-src.cabal
@@ -1,5 +1,5 @@
 Name:                cabal-src
-Version:             0.2.1
+Version:             0.2.2
 Synopsis:            Alternative install procedure to avoid the diamond dependency issue.
 Description:         Please see the README.md file on Github for more information: <https://github.com/yesodweb/cabal-src/blob/master/README.md>.
 License:             BSD3


### PR DESCRIPTION
This change makes cabal-src-install work with a build directory other than `dist`.