### PR TITLE
Restrict http-conduit version to < 2.2.0.

### DIFF
--- a/cabal-src.cabal
+++ b/cabal-src.cabal
@@ -26,7 +26,7 @@ Executable mega-sdist
   Build-depends:       base             >= 4              && < 5
                      , shelly           >= 1.3.1
                      , conduit          >= 1.1
-                     , http-conduit     >= 1.5
+                     , http-conduit     >= 1.5            && < 2.2.0
                      , system-filepath  >= 0.4            && < 0.5
                      , system-fileio    >= 0.3            && < 0.4
                      , http-types


### PR DESCRIPTION
After 2.2.0, http-conduit has replaced checkStatus (which is still
existing in document) with other totally different method. This breaks
the building of cabal-src-install. Issue #8 .